### PR TITLE
Fix error injection for remote assets

### DIFF
--- a/crossdomain.xml
+++ b/crossdomain.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<cross-domain-policy>
+  <allow-access-from domain="*" secure="false" />
+</cross-domain-policy>

--- a/live-hls.js
+++ b/live-hls.js
@@ -597,6 +597,7 @@ const parseMaster = function(request, response, body) {
   var line;
   var indexOfIp;
   var strm;
+  var urlParamValue;
 
   if (request.query.event) {
     eventType = request.query.event;
@@ -614,8 +615,9 @@ const parseMaster = function(request, response, body) {
             line = trimCharacters(lines[i].substr(uriIndex + 5), ['\'', '/', '.']).replace(/['"]+/g, '').replace(/(\r)/gm,"");
             indexOfLastSlash = fullurl.lastIndexOf('/');
             baseurl = fullurl.slice(0, indexOfLastSlash) + '/';
-            manifestUrl = `http://${request.headers.host}/${eventType}?url=${baseurl + trimCharacters(line, ['.', '/'])}`;
-            renditions.push(manifestUrl);
+            urlParamValue = baseurl + trimCharacters(line, ['.', '/']);
+            manifestUrl = `http://${request.headers.host}/${eventType}?url=${urlParamValue}`;
+            renditions.push(urlParamValue);
             lines[i] = lines[i].replace(line, manifestUrl);
           } else {
             line = trimCharacters(lines[i].substr(uriIndex + 5), ['\'', '/', '.']).replace(/['"]+/g, '');
@@ -630,9 +632,10 @@ const parseMaster = function(request, response, body) {
         indexOfLastSlash = fullurl.lastIndexOf('/');
         indexOfIp = fullurl.indexOf('master');
         baseurl = fullurl.slice(0, indexOfLastSlash) + '/';
-        manifestUrl = `http://${request.headers.host}/${eventType}?url=${baseurl + trimCharacters(lines[i], ['.', '/'])}`;
+        urlParamValue = baseurl + trimCharacters(lines[i], ['.', '/']);
+        manifestUrl = `http://${request.headers.host}/${eventType}?url=${urlParamValue}`;
         debuglog('manifestUrl: ' + manifestUrl);
-        renditions.push(manifestUrl);
+        renditions.push(urlParamValue);
         lines[i] = manifestUrl;
       } else {
         renditions.push(trimCharacters(lines[i], ['.','/']));

--- a/live-hls.js
+++ b/live-hls.js
@@ -886,7 +886,7 @@ const trimCharacters = function(str, char) {
  */
 
 const getManifestObjects = function (request, response, body, streamtype, fullurl) {
-  var baseurl, renditionName, manifestHeader, manifestResources, tsstreampath, result, playlist, duration;
+  var baseurl, renditionName, manifestHeader, manifestResources, tsstreampath, result, playlist, duration, targetStream;
   if (fullurl) {
     var indexOfLastSlash = fullurl.lastIndexOf('/');
     baseurl = fullurl.slice(0, indexOfLastSlash) + '/';
@@ -941,13 +941,13 @@ const getManifestObjects = function (request, response, body, streamtype, fullur
     tsstreampath = manifest[streampath].resources[event.lastStartPosition + event.window + 1].tsfile;
     tsstreampath = trimCharacters(tsstreampath, ['/', '.']);
     console.log('Target for 404: ' + tsstreampath);
-    stream = getStream(tsstreampath);
+    targetStream = getStream(tsstreampath);
     //Pass error value to the ts stream
-    if (stream.tsNotFound) {
-      stream.tsNotFound++;
+    if (targetStream.tsNotFound) {
+      targetStream.tsNotFound++;
     }
     else {
-      stream.tsNotFound = 1;
+      targetStream.tsNotFound = 1;
     }
     event.tsNotFound--;
   }

--- a/murphy
+++ b/murphy
@@ -78,7 +78,7 @@ app.use('/event', liveHls.eventFunction);
 // a.k.a. "sliding window"
 app.use('/live', liveHls.live);
 
-app.get('/crossdomain.xml'. function(req, res) {
+app.get('/crossdomain.xml', function(req, res) {
   res.sendFile(path.join(__dirname, 'crossdomain.xml'));
 });
 

--- a/murphy
+++ b/murphy
@@ -84,6 +84,7 @@ app.get('/crossdomain.xml', function(req, res) {
       return res.send(404, error);
     }
 
+    res.set('Content-Type', 'application/xml');
     res.send(data);
   });
 });

--- a/murphy
+++ b/murphy
@@ -5,6 +5,7 @@
 
 var
   express = require('express'),
+  path = require('path'),
   http = require('http'),
   app = express(),
   murphyPort = process.argv[2] || process.env.MURPHY_PORT || 9191,
@@ -76,6 +77,10 @@ app.use('/event', liveHls.eventFunction);
 // simulate live HLS playlists with limited seeking support,
 // a.k.a. "sliding window"
 app.use('/live', liveHls.live);
+
+app.get('/crossdomain.xml'. function(req, res) {
+  res.sendFile(path.join(__dirname, 'crossdomain.xml'));
+});
 
 http.createServer(app).listen(murphyPort, function() {
   console.log('listening for requests at', os.hostname(), 'on port', murphyPort);

--- a/murphy
+++ b/murphy
@@ -79,7 +79,13 @@ app.use('/event', liveHls.eventFunction);
 app.use('/live', liveHls.live);
 
 app.get('/crossdomain.xml', function(req, res) {
-  res.sendFile(path.join(__dirname, 'crossdomain.xml'));
+  fs.readFile(path.join(__dirname, 'crossdomain.xml'), function(error, data) {
+    if (error) {
+      return res.send(404, error);
+    }
+
+    res.send(data);
+  });
 });
 
 http.createServer(app).listen(murphyPort, function() {


### PR DESCRIPTION
This makes the ui and error injection logic work for remote assets

stream start/stop query params not fixed in this pr, but simple to add later by making checks for `request.path` like I do here

I also added crossdomain.xml to support flash players