### PR TITLE
Make stream stopping and resetting work when the associated query params are passed.

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -6,8 +6,8 @@
 </head>
 <body>
 <script>
-    injectError = function(theurl) {
-        document.getElementById('iframe').src=theurl;
+    makeRequest = function(theurl) {
+        document.getElementById('iframe').src = theurl;
     }
 </script>
 
@@ -21,8 +21,7 @@
 <table class="tg">
     <tr>
         <th class="tg-031e">Stream</th>
-        <th class="tg-yw4l"></th>
-        <th class="tg-yw4l"></th>
+        <th class="tg-yw4l" colspan="4"></th>
     </tr>
     <!--InjectRows-->
 </table>


### PR DESCRIPTION
Given that query params are all treated as strings the previous comparisons never matched.  This also adds buttons to the UI for stopping and resetting.